### PR TITLE
Módulos para formato de código de barras y para condicional del reporte de inventario

### DIFF
--- a/lot_barcode/__init__.py
+++ b/lot_barcode/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/lot_barcode/__manifest__.py
+++ b/lot_barcode/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': "Formato del reporte del lote con código de barras",
+    'summary': """
+    Se cambia el formato del reporte generado desde el lote, y el dato con el cual se genera el código de barras.
+    """, 
+    'description': """
+    Se cambia el formato del reporte generado desde el lote, y el dato con el cual se genera el código de barras.
+    """,
+    'author': "Quemari developers",
+    'website': "http://www.quemari.com",
+    'category': "Inventory",
+    'depends': [
+        'stock'
+    ],
+    'data': [
+        'report/report_lot_barcode.xml', 
+
+        'views/stock_production_lot_form_inherit_view.xml'
+    ]
+}

--- a/lot_barcode/models/__init__.py
+++ b/lot_barcode/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import stock_production_lot

--- a/lot_barcode/models/stock_production_lot.py
+++ b/lot_barcode/models/stock_production_lot.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+
+class StockProductionLot(models.Model): 
+    _inherit = 'stock.production.lot'
+
+    packing = fields.Char('Packing')

--- a/lot_barcode/report/report_lot_barcode.xml
+++ b/lot_barcode/report/report_lot_barcode.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+
+    <template id="report_lot_label_new" inherit_id="stock.report_lot_label">
+        <xpath expr="//t/t/t/div" position="replace">
+            <div class="page">
+                <div class="text-center">
+                    <span t-field="o.product_id.display_name" style="font-size: 120px;"/>
+                    <br/>
+                    <span t-field="o.name" style="font-size: 90px;"/>
+                    <br/>
+                    <span t-field="o.packing" style="font-size: 90px;"/>
+                </div>
+                <div class="oe_structure"/>
+                <div class="row" style="margin-left: 40px; margin-top: 50px;">
+                    <div class="col-6">
+                        <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3.5in; text-align: center;">
+                            <tr>
+                              <th>
+                                <span t-field="o.product_id.display_name"/>
+                              </th>
+                            </tr>
+                            <tr name="lot_name">
+                                <td>
+                                    <span>LN/SN:</span>
+                                    <span t-field="o.name"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <span t-field="o.packing"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="text-align: center; vertical-align: middle;" class="col-5">
+                                    <div t-field="o.id" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="col-6">
+                        <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3.5in; text-align: center;">
+                            <tr>
+                                <th>
+                                  <span t-field="o.product_id.display_name"/>
+                                </th>
+                              </tr>
+                              <tr name="lot_name">
+                                  <td>
+                                      <span>LN/SN:</span>
+                                      <span t-field="o.name"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <span t-field="o.packing"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td style="text-align: center; vertical-align: middle;" class="col-5">
+                                      <div t-field="o.id" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
+                                  </td>
+                              </tr>
+                        </table>
+                    </div>
+                </div>
+                <div class="row" style="margin-left: 40px; margin-top: 20px;">
+                    <div class="col-6">
+                        <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3.5in; text-align: center;">
+                            <tr>
+                                <th>
+                                  <span t-field="o.product_id.display_name"/>
+                                </th>
+                              </tr>
+                              <tr name="lot_name">
+                                  <td>
+                                      <span>LN/SN:</span>
+                                      <span t-field="o.name"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <span t-field="o.packing"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td style="text-align: center; vertical-align: middle;" class="col-5">
+                                      <div t-field="o.id" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
+                                  </td>
+                              </tr>
+                        </table>
+                    </div>
+                    <div class="col-6">
+                        <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3.5in; text-align: center;">
+                            <tr>
+                                <th>
+                                  <span t-field="o.product_id.display_name"/>
+                                </th>
+                              </tr>
+                              <tr name="lot_name">
+                                  <td>
+                                      <span>LN/SN:</span>
+                                      <span t-field="o.name"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td>
+                                      <span t-field="o.packing"/>
+                                  </td>
+                              </tr>
+                              <tr>
+                                  <td style="text-align: center; vertical-align: middle;" class="col-5">
+                                      <div t-field="o.id" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
+                                  </td>
+                              </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/lot_barcode/report/report_lot_barcode.xml
+++ b/lot_barcode/report/report_lot_barcode.xml
@@ -5,12 +5,29 @@
     <template id="report_lot_label_new" inherit_id="stock.report_lot_label">
         <xpath expr="//t/t/t/div" position="replace">
             <div class="page">
-                <div class="text-center">
-                    <span t-field="o.product_id.display_name" style="font-size: 120px;"/>
-                    <br/>
-                    <span t-field="o.name" style="font-size: 90px;"/>
-                    <br/>
-                    <span t-field="o.packing" style="font-size: 90px;"/>
+                <div class="row" style="margin-left: 35px;">
+                    <table class="table table-condensed" style="border-bottom: 0px solid white !important; text-align: center;">
+                        <tr>
+                            <th>
+                                <span t-field="o.product_id.display_name" style="font-size: 80px;"/>
+                            </th>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span t-field="o.name" style="font-size: 60px;"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span t-field="o.packing" style="font-size: 60px;"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="text-align: center; vertical-align: middle;" class="col-5">
+                                <div t-field="o.id" t-options="{'widget': 'barcode', 'width': 750, 'height': 250, 'img_style': 'width:100%;height:20%;'}"/>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
                 <div class="oe_structure"/>
                 <div class="row" style="margin-left: 40px; margin-top: 50px;">

--- a/lot_barcode/views/stock_production_lot_form_inherit_view.xml
+++ b/lot_barcode/views/stock_production_lot_form_inherit_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="stock_production_lot_form_inherit_view" model="ir.ui.view">
+        <field name="name">stock.prodution.lot.form.inherit.view</field>
+        <field name="model">stock.production.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="/form/sheet/group/group/div[@class='o_row']" position="after">
+                <field name="packing"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_over_credit_validation/__init__.py
+++ b/sale_order_over_credit_validation/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_order_over_credit_validation/__manifest__.py
+++ b/sale_order_over_credit_validation/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name' : "Validación para la confirmación de Sale Orders",
+    'summary' : """
+    Módulo que agrega una validación al momento de confirmar las sale orders, si el partner tiene facturas vencidas y no tiene permitido el over credit, no deja confirmar la orden
+    """, 
+    'author' : "Quemari developers",
+    'website' : "http://www.quemari.com", 
+    'category' : "Sales",
+    'depends' : [
+        'sale', 
+        'sale_management', 
+        'account',
+        'account_accountant',
+    ], 
+    'data' : [],
+}

--- a/sale_order_over_credit_validation/models/__init__.py
+++ b/sale_order_over_credit_validation/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order

--- a/sale_order_over_credit_validation/models/sale_order.py
+++ b/sale_order_over_credit_validation/models/sale_order.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+from datetime import datetime
+
+class SaleOrder(models.Model): 
+    _inherit = 'sale.order'
+
+    def action_confirm(self): 
+        today = datetime.now().date()
+        inv_ids = self.env['account.move'].search([('partner_id', '=', self.partner_id.id), ('state', '=', 'posted'), ('invoice_payment_state', '=', 'not_paid'), ('type', '=', 'out_invoice'), ('invoice_date_due', '<', today)])
+        if inv_ids and not self.partner_id.over_credit:
+            raise ValidationError (_("You can not confirm sale order for this Customer. This customer has one or more overdue invoices."))
+        return super(SaleOrder, self).action_confirm()

--- a/yellow_lot_inventory_report/__init__.py
+++ b/yellow_lot_inventory_report/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/yellow_lot_inventory_report/__manifest__.py
+++ b/yellow_lot_inventory_report/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+{
+    'name': "Color amarillo al lote con base a los alerts",
+    'summary': """
+    El color del lote en el reporte de inventario cambia a amarillo si han pasado cinco días, tomando como base el alert time
+    """,
+    'description': """
+    El color del lote en el reporte de inventario cambia a amarillo si han pasado cinco días, tomando como base el alert time
+    """,
+    'author': "Quemari developers",
+    'website': "http://www.quemari.com",
+    'category': "Inventory",
+    'depends': [
+        'stock'
+    ],
+    'data': [
+        'views/stock_quant_tree_editable_inherit_view.xml'
+    ]
+
+}

--- a/yellow_lot_inventory_report/models/__init__.py
+++ b/yellow_lot_inventory_report/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import stock_quant

--- a/yellow_lot_inventory_report/models/stock_quant.py
+++ b/yellow_lot_inventory_report/models/stock_quant.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from email.policy import default
+from odoo import fields, models, api, _
+from datetime import datetime
+import logging
+
+_logger = logging.getLogger(__name__)
+
+class StockQuant(models.Model): 
+    _inherit = 'stock.quant'
+
+    alert_date = fields.Datetime(related='lot_id.alert_date', store=True)
+
+    current_date = fields.Datetime(compute='_get_current_date')
+
+    def _get_current_date(self): 
+        self.current_date = datetime.now()
+
+

--- a/yellow_lot_inventory_report/views/stock_quant_tree_editable_inherit_view.xml
+++ b/yellow_lot_inventory_report/views/stock_quant_tree_editable_inherit_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+
+    <record id="stock_quant_tree_editable_inherit_view" model="ir.ui.view">
+        <field name="name">stock.quant.tree.editable.inherit.view</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree_editable"/>
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-warning"> alert_date &lt;= current_date</attribute>
+            </xpath>
+            <xpath expr="//tree/field[@name='lot_id']" position="after">
+                <field name="alert_date" invisible="1"/>
+                <field name="current_date" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Se agrega módulo que cambia el formato del pdf al momento de imprimir los códigos de barras por lote. También, se agrega módulo que pinta las líneas del reporte de inventario de color amarillo en caso de que el alert_time del producto se vea sobrepasado por la fecha actual